### PR TITLE
More conservative quoting

### DIFF
--- a/ckanext/datapusher_plus/jobs.py
+++ b/ckanext/datapusher_plus/jobs.py
@@ -568,7 +568,7 @@ def _push_to_datastore(task_id, input, dry_run=False, temp_dir=None):
         # Sniffer fails for XLSX files
         if not sniff_enabled:
             os.environ["QSV_SNIFF_DELIMITER"] = "false"
-    
+
         # if so, export spreadsheet as a CSV file
         default_excel_sheet = tk.config.get("ckanext.datapusher_plus.default_excel_sheet", 0)
         logger.info(
@@ -696,6 +696,8 @@ def _push_to_datastore(task_id, input, dry_run=False, temp_dir=None):
                     "input",
                     tmp,
                     "--trim-headers",
+                    # Default quoting style is "necessary" but it fails unexpectedly
+                    "--quote-style", "nonnumeric",
                     "--output",
                     qsv_input_csv,
                 ],


### PR DESCRIPTION
QSV fails to `validate` and `sniff` for files after the `input` command
This is due to the default `--quote-style neccesary` will drop all quotes.
If we preserve quotes for non numeric data with `--quote-style nonnumeric` it works better

This is a more conservative approach and probably fix the issue (at least if fixes our current private resource)