### PR TITLE
Fix pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,9 @@ setup(
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['tests*']),
 
+    # For pip install to include all files listed in MANIFEST.in
+    include_package_data=True,
+
     # setup_requires=['wheel'],
     # List run-time dependencies here.  These will be installed by pip when your
     # project is installed. For an analysis of "install_requires" vs pip's


### PR DESCRIPTION
Currently executing `pip install` will ignore all files listed in `MANIFEST.in` causing this extension to raise a `FileNotFoundError("config_declaration.EXT")` error.

This is currently working because we are executing a `pip install -e`, but it is not ideal.

The problem is that our `setup.py` file is missing a configuration: `include_package_data=True`